### PR TITLE
Add Form.section

### DIFF
--- a/examples/src/Form/View/MultiStage.elm
+++ b/examples/src/Form/View/MultiStage.elm
@@ -318,6 +318,9 @@ renderField ({ onChange, onBlur, disabled, showError } as fieldConfig) ( field, 
         Form.Group fields ->
             group (List.map (renderField fieldConfig) fields)
 
+        Form.Section title fields ->
+            section title (List.map (renderField fieldConfig) fields)
+
 
 inputField : String -> View.TextFieldConfig msg -> Html msg
 inputField type_ { onChange, onBlur, disabled, value, error, showError, attributes } =
@@ -454,6 +457,14 @@ selectField { onChange, onBlur, disabled, value, error, showError, attributes } 
 group : List (Html msg) -> Html msg
 group =
     Html.div [ Attributes.class "elm-form-group" ]
+
+
+section : String -> List (Html msg) -> Html msg
+section title fields =
+    Html.fieldset []
+        (Html.legend [] [ Html.text title ]
+            :: fields
+        )
 
 
 wrapInFieldContainer : Bool -> Maybe Error -> List (Html msg) -> Html msg

--- a/examples/src/Form/View/Ui.elm
+++ b/examples/src/Form/View/Ui.elm
@@ -41,6 +41,7 @@ layout =
         , radioField = radioField
         , selectField = selectField
         , group = group
+        , section = section
         }
 
 
@@ -220,6 +221,28 @@ group =
     row [ spacing 12 ]
 
 
+section : String -> List (Element msg) -> Element msg
+section title fields =
+    column
+        [ Border.solid
+        , Border.width 1
+        , padding 20
+        , width fill
+        , inFront
+            (el
+                [ moveUp 14
+                , moveRight 10
+                , Background.color black
+                , Font.color white
+                , padding 6
+                , width shrink
+                ]
+                (text title)
+            )
+        ]
+        fields
+
+
 errorToString : Error -> String
 errorToString error =
     case error of
@@ -361,6 +384,11 @@ gray =
 white : Color
 white =
     rgb 1 1 1
+
+
+black : Color
+black =
+    rgb 0 0 0
 
 
 button :

--- a/examples/src/Page/DynamicForm.elm
+++ b/examples/src/Page/DynamicForm.elm
@@ -133,7 +133,7 @@ questionForm =
                 , value = .title
                 , update = \value values -> { values | title = value }
                 , attributes =
-                    { label = "Question title"
+                    { label = "Title"
                     , placeholder = "Type your question here..."
                     }
                 }
@@ -144,7 +144,7 @@ questionForm =
                 , value = .body
                 , update = \value values -> { values | body = value }
                 , attributes =
-                    { label = "Question body"
+                    { label = "Body"
                     , placeholder = "Describe your question here... (optional)"
                     }
                 }
@@ -152,6 +152,7 @@ questionForm =
     Form.succeed NewQuestion
         |> Form.append titleField
         |> Form.append (Form.optional bodyField)
+        |> Form.section "Question"
 
 
 code : Html msg

--- a/examples/styles.scss
+++ b/examples/styles.scss
@@ -142,20 +142,6 @@ form.elm-form, form.elm-form-multistage {
     }
   }
 
-  > div.elm-form-group {
-    display: flex;
-    flex-direction: row;
-
-    > * {
-      flex-grow: 1;
-      flex-basis: 0;
-
-      &:not(:last-child) {
-        margin-right: 1em;
-      }
-    }
-  }
-
   .elm-form-error {
     color: red;
   }
@@ -192,6 +178,20 @@ form.elm-form, form.elm-form-multistage {
       cursor: default;
       background-color: #CCC;
       color: #888;
+    }
+  }
+}
+
+.elm-form-group {
+  display: flex;
+  flex-direction: row;
+
+  > * {
+    flex-grow: 1;
+    flex-basis: 0;
+
+    &:not(:last-child) {
+      margin-right: 1em;
     }
   }
 }

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -5,6 +5,7 @@ module Form exposing
     , succeed, append, optional, group, andThen, meta
     , map, mapValues
     , Field(..), TextType(..), fill
+    , section
     )
 
 {-| Build [composable forms](#Form) comprised of [fields](#fields).
@@ -405,6 +406,28 @@ group form =
         )
 
 
+{-| Wraps a form in a section: an area with a title.
+
+Like [`group`](#group), this function has no effect on form behavior. It just
+indicates to the form view function that the fields are part of some user-defined
+section.
+
+-}
+section : String -> Form values output -> Form values output
+section title form =
+    Base.custom
+        (\values ->
+            let
+                { fields, result, isEmpty } =
+                    Base.fill form values
+            in
+            { field = Section title fields
+            , result = result
+            , isEmpty = isEmpty
+            }
+        )
+
+
 {-| Fill a form `andThen` fill another one.
 
 This is useful to build dynamic forms. For instance, you could use the output of a `selectField`
@@ -594,6 +617,9 @@ mapValues { value, update } form =
 
                         Group fields ->
                             Group (List.map (\( field_, error ) -> ( mapField field_, error )) fields)
+
+                        Section title fields ->
+                            Section title (List.map (\( field_, error ) -> ( mapField field_, error )) fields)
             in
             form
                 |> Base.mapValues value
@@ -619,6 +645,7 @@ type Field values
     | Radio (RadioField values)
     | Select (SelectField values)
     | Group (List ( Field values, Maybe Error ))
+    | Section String (List ( Field values, Maybe Error ))
 
 
 {-| Represents a type of text field

--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -170,6 +170,7 @@ type alias CustomConfig msg element =
     , radioField : RadioFieldConfig msg -> element
     , selectField : SelectFieldConfig msg -> element
     , group : List element -> element
+    , section : String -> List element -> element
     }
 
 
@@ -336,6 +337,7 @@ a [`ViewConfig`](#ViewConfig). In fact, [`asHtml`](#asHtml) is implemented using
             , radioField = radioField
             , selectField = selectField
             , group = group
+            , section = section
             }
 
 -}
@@ -517,6 +519,9 @@ renderField customConfig ({ onChange, onBlur, disabled, showError } as fieldConf
         Form.Group fields ->
             customConfig.group (List.map (renderField customConfig fieldConfig) fields)
 
+        Form.Section title fields ->
+            customConfig.section title (List.map (renderField customConfig fieldConfig) fields)
+
 
 
 -- Basic HTML
@@ -572,6 +577,7 @@ asHtml =
         , radioField = radioField
         , selectField = selectField
         , group = group
+        , section = section
         }
 
 
@@ -746,6 +752,14 @@ selectField { onChange, onBlur, disabled, value, error, showError, attributes } 
 group : List (Html msg) -> Html msg
 group =
     Html.div [ Attributes.class "elm-form-group" ]
+
+
+section : String -> List (Html msg) -> Html msg
+section title fields =
+    Html.fieldset []
+        (Html.legend [] [ Html.text title ]
+            :: fields
+        )
 
 
 wrapInFieldContainer : Bool -> Maybe Error -> List (Html msg) -> Html msg


### PR DESCRIPTION
To see what this looks like, the dynamic form example page was updated to use it.

I think @hecrj finds form sections to encourage bad UI (and rightly so in most cases). But for admin forms, with lots of fields on the same page, I find it essential to be able to group a set of fields into a section with a title. (I seem to remember @benthomasveeva saying something similar). At least, I'd like to have a discussion about it and to discover a better approach, if there is one.