### PR TITLE
Implement `Base.disable` and `Form.disable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Form.disable` and `Form.Base.disable`, which allow disabling the fields of a
+  form. [#27]
+
+### Changed
+- `Form.Base.FilledField` has been renamed to `Form.Base.CustomField` and its
+  `field` property has been renamed to `state`. [#27]
+- The tuple `( field, Maybe Error )` is replaced with the new record
+  `Form.Base.FilledField` everywhere. [#27]
+
+[#27]: https://github.com/hecrj/composable-form/pull/27
 
 ## [7.1.0] - 2019-05-07
 ### Added

--- a/examples/src/Page/CustomFields/Form.elm
+++ b/examples/src/Page/CustomFields/Form.elm
@@ -43,7 +43,7 @@ customEmailField { onChange, state, attributes } =
                     state values
                         |> ComplexValidationField.value
             in
-            { field =
+            { state =
                 Email
                     { onChange = ComplexValidationField.ValueChanged >> onChange
                     , state =
@@ -121,7 +121,7 @@ fill :
     Form values output msg
     -> values
     ->
-        { fields : List ( Field values msg, Maybe Error )
+        { fields : List (Base.FilledField (Field values msg))
         , result : Result ( Error, List Error ) output
         , isEmpty : Bool
         }

--- a/examples/src/Page/CustomFields/Form/View.elm
+++ b/examples/src/Page/CustomFields/Form/View.elm
@@ -6,6 +6,7 @@ module Page.CustomFields.Form.View exposing
     , idle
     )
 
+import Form.Base as Base
 import Form.Error as Error exposing (Error)
 import Form.View
 import Html exposing (Html)
@@ -115,16 +116,16 @@ asHtml { onChange, action, loading } form model =
         )
 
 
-field : { disabled : Bool, showError : Bool } -> ( Form.Field values msg, Maybe Error ) -> Html msg
-field { disabled, showError } ( field_, maybeError ) =
-    case field_ of
+field : { disabled : Bool, showError : Bool } -> Base.FilledField (Form.Field values msg) -> Html msg
+field { disabled, showError } field_ =
+    case field_.state of
         Form.Email { onChange, state, value, attributes } ->
             emailField
                 { onChange = onChange
                 , onBlur = Nothing
                 , value = value
-                , disabled = disabled
-                , error = maybeError
+                , disabled = disabled || field_.isDisabled
+                , error = field_.error
                 , showError = state == Form.EmailValidated
                 , attributes = attributes
                 }

--- a/src/Form/Base.elm
+++ b/src/Form/Base.elm
@@ -1,9 +1,9 @@
 module Form.Base exposing
     ( Form
-    , field, FieldConfig, custom, FilledField
-    , succeed, append, andThen, optional, meta
+    , field, FieldConfig, custom, CustomField
+    , succeed, append, andThen, optional, disable, meta
     , map, mapValues, mapField
-    , FilledForm, fill
+    , FilledForm, FilledField, fill
     )
 
 {-| Build composable forms with your own custom fields.
@@ -46,12 +46,12 @@ For instance, you could start your own `MyProject.Form` module like this:
 Notice that we could avoid redefining `succeed`, `append`, and others, but that would force us to
 import `Form.Base` every time we needed to use those operations with our brand new form.
 
-@docs field, FieldConfig, custom, FilledField
+@docs field, FieldConfig, custom, CustomField
 
 
 # Composition
 
-@docs succeed, append, andThen, optional, meta
+@docs succeed, append, andThen, optional, disable, meta
 
 
 # Mapping
@@ -61,7 +61,7 @@ import `Form.Base` every time we needed to use those operations with our brand n
 
 # Output
 
-@docs FilledForm, fill
+@docs FilledForm, FilledField, fill
 
 -}
 
@@ -176,14 +176,14 @@ field { isEmpty } build config =
                         Err ( firstError, _ ) ->
                             ( Just firstError, firstError == Error.RequiredFieldIsEmpty )
             in
-            { fields = [ ( field_ values, error ) ]
+            { fields = [ { state = field_ values, error = error, isDisabled = False } ]
             , result = result
             , isEmpty = isEmpty_
             }
         )
 
 
-{-| Represents a field on a form that has been filled with values.
+{-| Represents a custom field on a form that has been filled with values.
 
 It contains:
 
@@ -192,8 +192,8 @@ It contains:
   - whether the field is empty or not
 
 -}
-type alias FilledField output field =
-    { field : field
+type alias CustomField output field =
+    { state : field
     , result : Result ( Error, List Error ) output
     , isEmpty : Bool
     }
@@ -208,7 +208,7 @@ You can check the [custom fields example][custom-fields] for some inspiration.
 [custom-fields]: https://hecrj.github.io/composable-form/#/custom-fields
 
 -}
-custom : (values -> FilledField output field) -> Form values output field
+custom : (values -> CustomField output field) -> Form values output field
 custom fillField =
     Form
         (\values ->
@@ -217,14 +217,16 @@ custom fillField =
                     fillField values
             in
             { fields =
-                [ ( filled.field
-                  , case filled.result of
-                        Ok _ ->
-                            Nothing
+                [ { state = filled.state
+                  , error =
+                        case filled.result of
+                            Ok _ ->
+                                Nothing
 
-                        Err ( firstError, _ ) ->
-                            Just firstError
-                  )
+                            Err ( firstError, _ ) ->
+                                Just firstError
+                  , isDisabled = False
+                  }
                 ]
             , result = filled.result
             , isEmpty = filled.isEmpty
@@ -337,7 +339,15 @@ optional form =
 
                 Err ( firstError, otherErrors ) ->
                     if filled.isEmpty then
-                        { fields = List.map (\( field_, _ ) -> ( field_, Nothing )) filled.fields
+                        { fields =
+                            List.map
+                                (\filledField ->
+                                    { state = filledField.state
+                                    , error = Nothing
+                                    , isDisabled = filledField.isDisabled
+                                    }
+                                )
+                                filled.fields
                         , result = Ok Nothing
                         , isEmpty = True
                         }
@@ -347,6 +357,31 @@ optional form =
                         , result = Err ( firstError, otherErrors )
                         , isEmpty = False
                         }
+        )
+
+
+{-| Like [`Form.disable`](Form#disable) but not tied to a particular type of `field`.
+-}
+disable : Form values output field -> Form values output field
+disable form =
+    Form
+        (\values ->
+            let
+                filled =
+                    fill form values
+            in
+            { fields =
+                List.map
+                    (\filledField ->
+                        { state = filledField.state
+                        , error = filledField.error
+                        , isDisabled = True
+                        }
+                    )
+                    filled.fields
+            , result = filled.result
+            , isEmpty = filled.isEmpty
+            }
         )
 
 
@@ -395,7 +430,15 @@ mapField fn form =
                 filled =
                     fill form values
             in
-            { fields = List.map (\( field_, error ) -> ( fn field_, error )) filled.fields
+            { fields =
+                List.map
+                    (\filledField ->
+                        { state = fn filledField.state
+                        , error = filledField.error
+                        , isDisabled = filledField.isDisabled
+                        }
+                    )
+                    filled.fields
             , result = filled.result
             , isEmpty = filled.isEmpty
             }
@@ -412,9 +455,18 @@ You can obtain this by using [`fill`](#fill).
 
 -}
 type alias FilledForm output field =
-    { fields : List ( field, Maybe Error )
+    { fields : List (FilledField field)
     , result : Result ( Error, List Error ) output
     , isEmpty : Bool
+    }
+
+
+{-| Represents a filled field.
+-}
+type alias FilledField field =
+    { state : field
+    , error : Maybe Error
+    , isDisabled : Bool
     }
 
 

--- a/src/Form/Base.elm
+++ b/src/Form/Base.elm
@@ -342,10 +342,7 @@ optional form =
                         { fields =
                             List.map
                                 (\filledField ->
-                                    { state = filledField.state
-                                    , error = Nothing
-                                    , isDisabled = filledField.isDisabled
-                                    }
+                                    { filledField | error = Nothing }
                                 )
                                 filled.fields
                         , result = Ok Nothing
@@ -373,10 +370,7 @@ disable form =
             { fields =
                 List.map
                     (\filledField ->
-                        { state = filledField.state
-                        , error = filledField.error
-                        , isDisabled = True
-                        }
+                        { filledField | isDisabled = True }
                     )
                     filled.fields
             , result = filled.result

--- a/src/Form/Base/FormList.elm
+++ b/src/Form/Base/FormList.elm
@@ -48,7 +48,7 @@ from the list.
 
 -}
 type alias Form values field =
-    { fields : List ( field, Maybe Error )
+    { fields : List (Base.FilledField field)
     , delete : () -> values
     }
 
@@ -164,7 +164,7 @@ form tagger { value, update, default, attributes } buildElement =
                                 Err ( currentHead, currentErrors ) ->
                                     Err ( head, errors ++ (currentHead :: currentErrors) )
             in
-            { field =
+            { state =
                 tagger
                     { forms = List.indexedMap toForm filledElements
                     , add = \_ -> update (listOfElementValues ++ [ default ]) values

--- a/tests/Base.elm
+++ b/tests/Base.elm
@@ -62,17 +62,17 @@ field =
 
         withFieldAndError fn result =
             case result.fields of
-                [ fieldAndError_ ] ->
-                    fn fieldAndError_
+                [ field_ ] ->
+                    fn field_
 
                 _ ->
                     Expect.fail "fields do not contain a single field"
 
         withField fn =
-            withFieldAndError (Tuple.first >> fn)
+            withFieldAndError (.state >> fn)
 
         withFieldError fn =
-            withFieldAndError (Tuple.second >> fn)
+            withFieldAndError (.error >> fn)
     in
     describe "Form.Base.field"
         [ describe "when filled"
@@ -178,7 +178,7 @@ custom =
         form =
             Form.Base.custom
                 (\value ->
-                    { field = CustomField
+                    { state = CustomField
                     , result =
                         if value == invalidValue then
                             Err
@@ -202,7 +202,12 @@ custom =
             \_ ->
                 fill "hello"
                     |> Expect.equal
-                        { fields = [ ( CustomField, Nothing ) ]
+                        { fields =
+                            [ { state = CustomField
+                              , error = Nothing
+                              , isDisabled = False
+                              }
+                            ]
                         , result = Ok "valid"
                         , isEmpty = False
                         }
@@ -211,9 +216,10 @@ custom =
                 fill invalidValue
                     |> Expect.equal
                         { fields =
-                            [ ( CustomField
-                              , Just (Error.ValidationFailed "error 1")
-                              )
+                            [ { state = CustomField
+                              , error = Just (Error.ValidationFailed "error 1")
+                              , isDisabled = False
+                              }
                             ]
                         , result =
                             Err
@@ -305,7 +311,7 @@ append =
                 \_ ->
                     fill validValues
                         |> .fields
-                        |> List.map Tuple.second
+                        |> List.map .error
                         |> Expect.equal [ Nothing, Nothing ]
             , test "results in the correct output" <|
                 \_ ->
@@ -318,7 +324,7 @@ append =
                 \_ ->
                     fill invalidValues
                         |> .fields
-                        |> List.map Tuple.second
+                        |> List.map .error
                         |> Expect.equal
                             [ Just (Error.ValidationFailed emailError)
                             , Just (Error.ValidationFailed passwordError)
@@ -488,7 +494,7 @@ optional =
                 \_ ->
                     fill emptyValues
                         |> .fields
-                        |> List.map Tuple.second
+                        |> List.map .error
                         |> Expect.equal [ Nothing, Nothing ]
             , test "produces Nothing" <|
                 \_ ->
@@ -501,7 +507,7 @@ optional =
                 \_ ->
                     fill validValues
                         |> .fields
-                        |> List.map Tuple.second
+                        |> List.map .error
                         |> Expect.equal [ Nothing, Nothing ]
             , test "results in the correct output" <|
                 \_ ->
@@ -521,7 +527,7 @@ optional =
                 \_ ->
                     fill invalidValues
                         |> .fields
-                        |> List.map Tuple.second
+                        |> List.map .error
                         |> Expect.equal
                             [ Just (Error.ValidationFailed emailError)
                             , Just (Error.ValidationFailed passwordError)


### PR DESCRIPTION
Fixes #19.

### Added
- `Form.disable` and `Form.Base.disable`, which allow disabling the fields of a form.

### Changed
- `Form.Base.FilledField` has been renamed to `Form.Base.CustomField` and its `field` property has been renamed to `state`.
- The tuple `( field, Maybe Error )` is replaced with the new record `Form.Base.FilledField` everywhere.