### PR TITLE
use on change to support ie and edge

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -22,6 +22,7 @@
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
+        "elm/json": "1.1.3 <= v < 2.0.0",
         "elm-community/list-extra": "8.0.0 <= v < 9.0.0"
     },
     "test-dependencies": {

--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -53,6 +53,7 @@ import Form.Error as Error exposing (Error)
 import Html exposing (Html)
 import Html.Attributes as Attributes
 import Html.Events as Events
+import Json.Decode
 import Set exposing (Set)
 
 
@@ -877,7 +878,7 @@ selectField { onChange, onBlur, disabled, value, error, showError, attributes } 
                 [ Html.text ("-- " ++ attributes.placeholder ++ " --") ]
     in
     Html.select
-        ([ Events.onInput onChange
+        ([ Events.on "change" (Json.Decode.map onChange Events.targetValue)
          , Attributes.disabled disabled
          ]
             |> withMaybeAttribute Events.onBlur onBlur


### PR DESCRIPTION
Both IE 11 and Edge don't support using the "input" event for select inputs. You have to use the "change" event. I wish this change didn't require a new direct dependency so that the version bump could be small. I couldn't think of a way to get around it though. I didn't mess with the json version requirement at all - I'm not sure what the best strategy is for picking the min dependency version.