### PR TITLE
Implement server-side error support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `field` property has been renamed to `state`. [#27]
 - The tuple `( field, Maybe Error )` is replaced with the new record
   `Form.Base.FilledField` everywhere. [#27]
+- An `error : values -> Maybe String` attribute was added to field configuration.
+  Useful to show server-side validation errors. [#29]
+- The `Error` type was extended with an `External` value. [#29]
 
 [#27]: https://github.com/hecrj/composable-form/pull/27
+[#29]: https://github.com/hecrj/composable-form/pull/29
 
 ## [7.1.0] - 2019-05-07
 ### Added

--- a/elm.json
+++ b/elm.json
@@ -26,6 +26,7 @@
         "elm-community/list-extra": "8.0.0 <= v < 9.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "1.1.0 <= v < 2.0.0"
+        "elm-explorations/test": "1.1.0 <= v < 2.0.0",
+        "elm/virtual-dom": "1.0.0 <= v < 2.0.0"
     }
 }

--- a/examples/src/Form/View/Ui.elm
+++ b/examples/src/Form/View/Ui.elm
@@ -267,6 +267,9 @@ errorToString error =
         Error.ValidationFailed validationError ->
             validationError
 
+        Error.External externalError ->
+            externalError
+
 
 
 -- Common Elements

--- a/examples/src/Page/Composability/Simple.elm
+++ b/examples/src/Page/Composability/Simple.elm
@@ -69,6 +69,7 @@ form =
                 { parser = EmailAddress.parse
                 , value = .email
                 , update = \value values -> { values | email = value }
+                , error = always Nothing
                 , attributes =
                     { label = "E-Mail"
                     , placeholder = "some@email.com"
@@ -80,6 +81,7 @@ form =
                 { parser = User.parseName
                 , value = .name
                 , update = \value values -> { values | name = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Name"
                     , placeholder = "Your name"

--- a/examples/src/Page/Composability/Simple/AddressForm.elm
+++ b/examples/src/Page/Composability/Simple/AddressForm.elm
@@ -27,6 +27,7 @@ form =
                 { parser = Address.parseCountry
                 , value = .country
                 , update = \value values -> { values | country = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Country"
                     , placeholder = "Type your country"
@@ -38,6 +39,7 @@ form =
                 { parser = Address.parseCity
                 , value = .city
                 , update = \value values -> { values | city = value }
+                , error = always Nothing
                 , attributes =
                     { label = "City"
                     , placeholder = "Type your city"
@@ -49,6 +51,7 @@ form =
                 { parser = Address.parsePostalCode
                 , value = .postalCode
                 , update = \value values -> { values | postalCode = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Postal Code"
                     , placeholder = "Type your postal code"

--- a/examples/src/Page/CustomFields/Form/View.elm
+++ b/examples/src/Page/CustomFields/Form/View.elm
@@ -198,3 +198,6 @@ errorToString error =
 
         Error.ValidationFailed validationError ->
             validationError
+
+        Error.External externalError ->
+            externalError

--- a/examples/src/Page/DynamicForm.elm
+++ b/examples/src/Page/DynamicForm.elm
@@ -87,6 +87,7 @@ publicationForm =
                                 Err "Invalid publication type"
                 , value = .publicationType
                 , update = \value values -> { values | publicationType = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Type of publication"
                     , placeholder = "Choose a type"
@@ -114,6 +115,7 @@ postForm =
                 { parser = Post.parseBody
                 , value = .body
                 , update = \value values -> { values | body = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Body"
                     , placeholder = "Type your post here..."
@@ -133,6 +135,7 @@ questionForm =
                 { parser = Question.parseTitle
                 , value = .title
                 , update = \value values -> { values | title = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Title"
                     , placeholder = "Type your question here..."
@@ -144,6 +147,7 @@ questionForm =
                 { parser = Question.parseBody
                 , value = .body
                 , update = \value values -> { values | body = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Body"
                     , placeholder = "Describe your question here... (optional)"

--- a/examples/src/Page/FormList.elm
+++ b/examples/src/Page/FormList.elm
@@ -68,6 +68,7 @@ form =
                 { parser = User.parseName
                 , value = .name
                 , update = \value values -> { values | name = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Your name"
                     , placeholder = "Type your name"
@@ -114,6 +115,7 @@ websiteForm index =
                 { parser = Ok
                 , value = .name
                 , update = \value values -> { values | name = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Name of website #" ++ String.fromInt (index + 1)
                     , placeholder = ""
@@ -125,6 +127,7 @@ websiteForm index =
                 { parser = Ok
                 , value = .address
                 , update = \value values -> { values | address = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Address of website #" ++ String.fromInt (index + 1)
                     , placeholder = "https://..."

--- a/examples/src/Page/Login.elm
+++ b/examples/src/Page/Login.elm
@@ -67,6 +67,7 @@ form =
                 { parser = EmailAddress.parse
                 , value = .email
                 , update = \value values -> { values | email = value }
+                , error = always Nothing
                 , attributes =
                     { label = "E-Mail"
                     , placeholder = "some@email.com"
@@ -78,6 +79,7 @@ form =
                 { parser = Ok
                 , value = .password
                 , update = \value values -> { values | password = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Password"
                     , placeholder = "Your password"
@@ -89,6 +91,7 @@ form =
                 { parser = Ok
                 , value = .rememberMe
                 , update = \value values -> { values | rememberMe = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Remember me" }
                 }

--- a/examples/src/Page/ValidationStrategies.elm
+++ b/examples/src/Page/ValidationStrategies.elm
@@ -74,6 +74,7 @@ form =
                 { parser = Ok
                 , value = .validationStrategy
                 , update = \value values -> { values | validationStrategy = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Validation strategy"
                     , options =
@@ -95,6 +96,7 @@ form =
                 { parser = EmailAddress.parse
                 , value = .email
                 , update = \value values -> { values | email = value }
+                , error = always Nothing
                 , attributes =
                     { label = "E-Mail"
                     , placeholder = "some@email.com"
@@ -106,6 +108,7 @@ form =
                 { parser = User.parseName
                 , value = .name
                 , update = \value values -> { values | name = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Name"
                     , placeholder = "Your name"
@@ -117,6 +120,7 @@ form =
                 { parser = User.parsePassword
                 , value = .password
                 , update = \value values -> { values | password = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Password"
                     , placeholder = "Your password"

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -135,6 +135,7 @@ textField :
     { parser : String -> Result String output
     , value : values -> String
     , update : String -> values -> values
+    , error : values -> Maybe String
     , attributes : TextField.Attributes
     }
     -> Form values output
@@ -151,6 +152,7 @@ emailField :
     { parser : String -> Result String output
     , value : values -> String
     , update : String -> values -> values
+    , error : values -> Maybe String
     , attributes : TextField.Attributes
     }
     -> Form values output
@@ -167,6 +169,7 @@ passwordField :
     { parser : String -> Result String output
     , value : values -> String
     , update : String -> values -> values
+    , error : values -> Maybe String
     , attributes : TextField.Attributes
     }
     -> Form values output
@@ -183,6 +186,7 @@ textareaField :
     { parser : String -> Result String output
     , value : values -> String
     , update : String -> values -> values
+    , error : values -> Maybe String
     , attributes : TextField.Attributes
     }
     -> Form values output
@@ -199,6 +203,7 @@ searchField :
     { parser : String -> Result String output
     , value : values -> String
     , update : String -> values -> values
+    , error : values -> Maybe String
     , attributes : TextField.Attributes
     }
     -> Form values output
@@ -218,6 +223,7 @@ numberField :
     { parser : Maybe Float -> Result String output
     , value : values -> Maybe Float
     , update : Maybe Float -> values -> values
+    , error : values -> Maybe String
     , attributes : NumberField.Attributes Float
     }
     -> Form values output
@@ -237,6 +243,7 @@ rangeField :
     { parser : Maybe Float -> Result String output
     , value : values -> Maybe Float
     , update : Maybe Float -> values -> values
+    , error : values -> Maybe String
     , attributes : RangeField.Attributes Float
     }
     -> Form values output
@@ -257,6 +264,7 @@ checkboxField :
     { parser : Bool -> Result String output
     , value : values -> Bool
     , update : Bool -> values -> values
+    , error : values -> Maybe String
     , attributes : CheckboxField.Attributes
     }
     -> Form values output
@@ -276,6 +284,7 @@ radioField :
     { parser : String -> Result String output
     , value : values -> String
     , update : String -> values -> values
+    , error : values -> Maybe String
     , attributes : RadioField.Attributes
     }
     -> Form values output
@@ -295,6 +304,7 @@ selectField :
     { parser : String -> Result String output
     , value : values -> String
     , update : String -> values -> values
+    , error : values -> Maybe String
     , attributes : SelectField.Attributes
     }
     -> Form values output

--- a/src/Form/Base/RangeField.elm
+++ b/src/Form/Base/RangeField.elm
@@ -62,7 +62,7 @@ form :
     (RangeField number values -> field)
     -> Config number values output
     -> Base.Form values output field
-form build { parser, value, update, attributes } =
+form build { parser, value, update, error, attributes } =
     let
         withDefault maybeValue =
             case maybeValue of
@@ -77,5 +77,6 @@ form build { parser, value, update, attributes } =
         { parser = parser
         , value = value >> withDefault
         , update = update
+        , error = error
         , attributes = attributes
         }

--- a/src/Form/Error.elm
+++ b/src/Form/Error.elm
@@ -15,8 +15,11 @@ custom view code.
 It can either be:
 
   - `RequiredFieldIsEmpty`, meaning that a required field is empty.
-  - `ValidationFailed`, meaning the field validation has failed. This type of error contains a
-    `String` describing the validation error.
+  - `ValidationFailed`, meaning the field validation has failed. This type of
+    error contains a `String` describing the validation error.
+  - `External`, meaning the field has an external error that cannot be validated
+    on the client. This mostly contains errors directly assigned to the field
+    on form construction using the `error` attribute.
 
 These type of errors are returned alongside each field in the [`Form.fill`](Form#fill) and
 [`Form.Base.fill`](Form-Base#fill) functions.
@@ -36,3 +39,4 @@ You can easily write a simple function that turns this type into a `String`:
 type Error
     = RequiredFieldIsEmpty
     | ValidationFailed String
+    | External String

--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -963,6 +963,9 @@ errorToString error =
         Error.ValidationFailed validationError ->
             validationError
 
+        Error.External externalError ->
+            externalError
+
 
 withMaybeAttribute : (a -> Html.Attribute msg) -> Maybe a -> List (Html.Attribute msg) -> List (Html.Attribute msg)
 withMaybeAttribute toAttribute maybeValue attrs =

--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -537,12 +537,12 @@ renderField customConfig ({ onChange, onBlur, disabled, showError } as fieldConf
 
         Form.Group fields ->
             fields
-                |> List.map (maybeIgnoreChildError field.error >> renderField customConfig { fieldConfig | disabled = field.isDisabled })
+                |> List.map (maybeIgnoreChildError field.error >> renderField customConfig { fieldConfig | disabled = field.isDisabled || disabled })
                 |> customConfig.group
 
         Form.Section title fields ->
             fields
-                |> List.map (maybeIgnoreChildError field.error >> renderField customConfig { fieldConfig | disabled = field.isDisabled })
+                |> List.map (maybeIgnoreChildError field.error >> renderField customConfig { fieldConfig | disabled = field.isDisabled || disabled })
                 |> customConfig.section title
 
         Form.List { forms, add, attributes } ->
@@ -934,14 +934,19 @@ fieldLabel label =
 
 maybeErrorMessage : Bool -> Maybe Error -> Html msg
 maybeErrorMessage showError maybeError =
-    if showError then
-        maybeError
-            |> Maybe.map errorToString
-            |> Maybe.map errorMessage
-            |> Maybe.withDefault (Html.text "")
+    case maybeError of
+        Just (Error.External externalError) ->
+            errorMessage externalError
 
-    else
-        Html.text ""
+        _ ->
+            if showError then
+                maybeError
+                    |> Maybe.map errorToString
+                    |> Maybe.map errorMessage
+                    |> Maybe.withDefault (Html.text "")
+
+            else
+                Html.text ""
 
 
 successMessage : String -> Html msg

--- a/tests/Base.elm
+++ b/tests/Base.elm
@@ -48,11 +48,21 @@ field =
                             Ok string
                 , value = identity
                 , update = \value _ -> value
+                , error =
+                    \string ->
+                        if string == externalErrorString then
+                            Just "external error"
+
+                        else
+                            Nothing
                 , attributes = attributes
                 }
 
         invalidString =
             "invalid"
+
+        externalErrorString =
+            "external_error"
 
         attributes =
             { a = 1, b = "some attribute" }
@@ -158,7 +168,23 @@ field =
                         |> Expect.equal (Err ( Error.ValidationFailed "invalid input", [] ))
             , test "form is not empty" <|
                 \_ ->
-                    fill "hello"
+                    fill invalidString
+                        |> .isEmpty
+                        |> Expect.equal False
+            ]
+        , describe "when there is an external error" <|
+            [ test "field error is External" <|
+                \_ ->
+                    fill externalErrorString
+                        |> withFieldError (Expect.equal (Just (Error.External "external error")))
+            , test "result is an External error" <|
+                \_ ->
+                    fill externalErrorString
+                        |> .result
+                        |> Expect.equal (Err ( Error.External "external error", [] ))
+            , test "form is not empty" <|
+                \_ ->
+                    fill externalErrorString
                         |> .isEmpty
                         |> Expect.equal False
             ]
@@ -368,6 +394,7 @@ andThen =
                 { parser = Ok
                 , value = .title
                 , update = \value values -> { values | title = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Title"
                     , placeholder = "Write a title..."
@@ -379,6 +406,7 @@ andThen =
                 { parser = Ok
                 , value = .body
                 , update = \value values -> { values | body = value }
+                , error = always Nothing
                 , attributes =
                     { label = "Body"
                     , placeholder = "Write the body..."
@@ -591,6 +619,7 @@ emailField =
                     Err emailError
         , value = .email
         , update = \value values -> { values | email = value }
+        , error = always Nothing
         , attributes =
             { label = "E-Mail"
             , placeholder = "Type your e-mail..."
@@ -619,6 +648,7 @@ passwordField =
                     Err passwordError
         , value = .password
         , update = \value values -> { values | password = value }
+        , error = always Nothing
         , attributes =
             { label = "Password"
             , placeholder = "Type your password..."
@@ -651,6 +681,7 @@ repeatPasswordField =
                 , update =
                     \newValue values_ ->
                         { values_ | repeatPassword = newValue }
+                , error = always Nothing
                 , attributes =
                     { label = "Repeat password"
                     , placeholder = "Type your password again..."
@@ -689,6 +720,7 @@ contentTypeField =
                         Err contentTypeError
         , value = .contentType
         , update = \value values -> { values | contentType = value }
+        , error = always Nothing
         , attributes =
             { label = "Content type"
             , placeholder = "Select a type of content"

--- a/tests/View.elm
+++ b/tests/View.elm
@@ -48,6 +48,9 @@ optionalGroup =
                 Just (Error.ValidationFailed validationError) ->
                     validationError
 
+                Just (Error.External externalError) ->
+                    externalError
+
                 Nothing ->
                     ""
     in
@@ -87,6 +90,7 @@ nameField =
         { parser = Ok
         , value = .name
         , update = \value values -> { values | name = value }
+        , error = always Nothing
         , attributes =
             { label = "Name"
             , placeholder = "Type your name..."
@@ -100,6 +104,7 @@ surnameField =
         { parser = Ok
         , value = .surname
         , update = \value values -> { values | surname = value }
+        , error = always Nothing
         , attributes =
             { label = "Surname"
             , placeholder = "Type your surname..."


### PR DESCRIPTION
Fixes #20.

This PR basically adds an `error : values -> Maybe String` attribute to field configuration.

It also extends the `Error` type with an `External` value. This way the `View` can choose to treat these errors differently.

I have also changed the `Signup` example to showcase its usage.