### PR TITLE
Number Fields use String value storage; allow step="any" attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - An `error : values -> Maybe String` attribute was added to field configuration.
   Useful to show server-side validation errors. [#29]
 - The `Error` type was extended with an `External` value. [#29]
+- `NumberField` value storage has been changed from `Maybe Float` to `String` to
+  fix issues entering values after the decimal point. [#25] & [#30]
+- The `step` item in the `Form.Base.NumberField.Attributes` record has been changed
+  from `number` to `Maybe number` to allow a step attribute of `"any"`. [#30]
 
+[#25]: https://github.com/hecrj/composable-form/issues/25
 [#27]: https://github.com/hecrj/composable-form/pull/27
 [#29]: https://github.com/hecrj/composable-form/pull/29
+[#30]: https://github.com/hecrj/composable-form/pull/30
 
 ## [7.1.0] - 2019-05-07
 ### Added

--- a/examples/src/Form/View/Ui.elm
+++ b/examples/src/Form/View/Ui.elm
@@ -139,16 +139,22 @@ textareaField { onChange, onBlur, disabled, value, error, showError, attributes 
 
 numberField : NumberFieldConfig msg -> Element msg
 numberField { onChange, onBlur, disabled, value, error, showError, attributes } =
+    let
+        stepAttr =
+            attributes.step
+                |> Maybe.map String.fromFloat
+                |> Maybe.withDefault "any"
+    in
     Input.text
         ([]
             |> withHtmlAttribute Html.Attributes.type_ (Just "number")
-            |> withHtmlAttribute (String.fromFloat >> Html.Attributes.step) (Just attributes.step)
+            |> withHtmlAttribute Html.Attributes.step (Just stepAttr)
             |> withHtmlAttribute (String.fromFloat >> Html.Attributes.max) attributes.max
             |> withHtmlAttribute (String.fromFloat >> Html.Attributes.min) attributes.min
             |> withCommonAttrs showError error disabled onBlur
         )
-        { onChange = fromString String.toFloat value >> onChange
-        , text = value |> Maybe.map String.fromFloat |> Maybe.withDefault ""
+        { onChange = onChange
+        , text = value
         , placeholder = placeholder attributes
         , label = labelAbove (showError && error /= Nothing) attributes
         }

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -220,9 +220,9 @@ It has a very similar configuration to [`textField`](#textField), the only diffe
 
 -}
 numberField :
-    { parser : Maybe Float -> Result String output
-    , value : values -> Maybe Float
-    , update : Maybe Float -> values -> values
+    { parser : String -> Result String output
+    , value : values -> String
+    , update : String -> values -> values
     , error : values -> Maybe String
     , attributes : NumberField.Attributes Float
     }

--- a/src/Form/Base/NumberField.elm
+++ b/src/Form/Base/NumberField.elm
@@ -28,7 +28,7 @@ custom fields or writing custom view code.
 
 -}
 type alias NumberField number values =
-    Field (Attributes number) (Maybe number) values
+    Field (Attributes number) String values
 
 
 {-| The attributes of a NumberField.
@@ -39,11 +39,13 @@ You need to provide these to:
 
 [numberField]: Form#numberField
 
+  - Its `step` is a Maybe -- `Nothing` represents the HTML attribute value of "any". If you want only integers allowed, use `Just 1`.
+
 -}
 type alias Attributes number =
     { label : String
     , placeholder : String
-    , step : number
+    , step : Maybe number
     , min : Maybe number
     , max : Maybe number
     }
@@ -57,7 +59,7 @@ custom fields.
 -}
 form :
     (NumberField number values -> field)
-    -> Base.FieldConfig (Attributes number) (Maybe number) values output
+    -> Base.FieldConfig (Attributes number) String values output
     -> Base.Form values output field
 form =
-    Base.field { isEmpty = (==) Nothing }
+    Base.field { isEmpty = String.isEmpty }

--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -224,18 +224,18 @@ type alias TextFieldConfig msg =
 
 {-| Describes how a number field should be rendered.
 
-  - `onChange` accepts a `Maybe` so the field value can be cleared.
-  - `value` will be `Nothing` if the field is blank or `Just` a `Float`.
+  - `onChange` takes a new value for the field and returns the `msg` that should be produced.
+  - `value` contains the current value of the field.
   - `attributes` are [`NumberField.Attributes`](Form-Base-NumberField#Attributes).
 
 The other record fields are described in [`TextFieldConfig`](#TextFieldConfig).
 
 -}
 type alias NumberFieldConfig msg =
-    { onChange : Maybe Float -> msg
+    { onChange : String -> msg
     , onBlur : Maybe msg
     , disabled : Bool
-    , value : Maybe Float
+    , value : String
     , error : Maybe Error
     , showError : Bool
     , attributes : NumberField.Attributes Float
@@ -781,13 +781,19 @@ textareaField { onChange, onBlur, disabled, value, error, showError, attributes 
 
 numberField : NumberFieldConfig msg -> Html msg
 numberField { onChange, onBlur, disabled, value, error, showError, attributes } =
+    let
+        stepAttr =
+            attributes.step
+                |> Maybe.map String.fromFloat
+                |> Maybe.withDefault "any"
+    in
     Html.input
-        ([ Events.onInput (fromString String.toFloat value >> onChange)
+        ([ Events.onInput onChange
          , Attributes.disabled disabled
-         , Attributes.value (value |> Maybe.map String.fromFloat |> Maybe.withDefault "")
+         , Attributes.value value
          , Attributes.placeholder attributes.placeholder
          , Attributes.type_ "number"
-         , Attributes.step (String.fromFloat attributes.step)
+         , Attributes.step stepAttr
          ]
             |> withMaybeAttribute (String.fromFloat >> Attributes.max) attributes.max
             |> withMaybeAttribute (String.fromFloat >> Attributes.min) attributes.min


### PR DESCRIPTION
_Note: this PR requires bumping the package version, I believe it can go with the rest of the 8.0 changes currently in master. Should it miss 8.0, a new version bump would need to be added._

As discussed in #25, storing number fields' values as `Maybe Float`s caused issues when entering decimal values. This updates number fields' value storage to use `String`.

Also related to decimals in number fields, the HTML spec [allows the step attribute to be set to "any"](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#step) to allow arbitrary precision. (If the `step` attribute is not present on the number input, the default is a step value of 1 (Integers only)). Making use of the "any" value is of interest to our app.

Accordingly, I changed the `step` item in NumberField.Attributes from `number` to `Maybe number`-- The idea being specifying `Nothing` means any step value is allowed. 

Step could probably be more elegantly and clearly modeled with a custom type — do we want to introduce that level of complexity? Something like:
```elm
type NumberStep number
    = AnyStep
    | Step number
```
I feel like using Maybe is consistent with the rest of the Api design, but let me know if you prefer the custom type, I'm happy to add it if you'd prefer.