### PR TITLE
add HTML attributes

### DIFF
--- a/examples/src/Form/View/Ui.elm
+++ b/examples/src/Form/View/Ui.elm
@@ -223,6 +223,7 @@ selectField { onChange, onBlur, disabled, value, error, showError, attributes } 
         , attributes =
             { label = attributes.label
             , options = attributes.options
+            , htmlAttributes = []
             }
         }
 

--- a/examples/src/Page/Composability/Simple.elm
+++ b/examples/src/Page/Composability/Simple.elm
@@ -73,6 +73,7 @@ form =
                 , attributes =
                     { label = "E-Mail"
                     , placeholder = "some@email.com"
+                    , htmlAttributes = []
                     }
                 }
 
@@ -85,6 +86,7 @@ form =
                 , attributes =
                     { label = "Name"
                     , placeholder = "Your name"
+                    , htmlAttributes = []
                     }
                 }
     in

--- a/examples/src/Page/Composability/Simple/AddressForm.elm
+++ b/examples/src/Page/Composability/Simple/AddressForm.elm
@@ -31,6 +31,7 @@ form =
                 , attributes =
                     { label = "Country"
                     , placeholder = "Type your country"
+                    , htmlAttributes = []
                     }
                 }
 
@@ -43,6 +44,7 @@ form =
                 , attributes =
                     { label = "City"
                     , placeholder = "Type your city"
+                    , htmlAttributes = []
                     }
                 }
 
@@ -55,6 +57,7 @@ form =
                 , attributes =
                     { label = "Postal Code"
                     , placeholder = "Type your postal code"
+                    , htmlAttributes = []
                     }
                 }
     in

--- a/examples/src/Page/CustomFields.elm
+++ b/examples/src/Page/CustomFields.elm
@@ -74,6 +74,7 @@ form =
                 , attributes =
                     { label = "Server-side validated e-mail"
                     , placeholder = "some@email.com"
+                    , htmlAttributes = []
                     }
                 }
     in

--- a/examples/src/Page/DynamicForm.elm
+++ b/examples/src/Page/DynamicForm.elm
@@ -92,6 +92,7 @@ publicationForm =
                     { label = "Type of publication"
                     , placeholder = "Choose a type"
                     , options = [ ( "post", "Post" ), ( "question", "Question" ) ]
+                    , htmlAttributes = []
                     }
                 }
     in
@@ -119,6 +120,7 @@ postForm =
                 , attributes =
                     { label = "Body"
                     , placeholder = "Type your post here..."
+                    , htmlAttributes = []
                     }
                 }
     in
@@ -139,6 +141,7 @@ questionForm =
                 , attributes =
                     { label = "Title"
                     , placeholder = "Type your question here..."
+                    , htmlAttributes = []
                     }
                 }
 
@@ -151,6 +154,7 @@ questionForm =
                 , attributes =
                     { label = "Body"
                     , placeholder = "Describe your question here... (optional)"
+                    , htmlAttributes = []
                     }
                 }
     in

--- a/examples/src/Page/FormList.elm
+++ b/examples/src/Page/FormList.elm
@@ -72,6 +72,7 @@ form =
                 , attributes =
                     { label = "Your name"
                     , placeholder = "Type your name"
+                    , htmlAttributes = []
                     }
                 }
     in
@@ -119,6 +120,7 @@ websiteForm index =
                 , attributes =
                     { label = "Name of website #" ++ String.fromInt (index + 1)
                     , placeholder = ""
+                    , htmlAttributes = []
                     }
                 }
 
@@ -131,6 +133,7 @@ websiteForm index =
                 , attributes =
                     { label = "Address of website #" ++ String.fromInt (index + 1)
                     , placeholder = "https://..."
+                    , htmlAttributes = []
                     }
                 }
     in

--- a/examples/src/Page/Login.elm
+++ b/examples/src/Page/Login.elm
@@ -71,6 +71,7 @@ form =
                 , attributes =
                     { label = "E-Mail"
                     , placeholder = "some@email.com"
+                    , htmlAttributes = [ ( "autocomplete", "email" ) ]
                     }
                 }
 
@@ -83,6 +84,7 @@ form =
                 , attributes =
                     { label = "Password"
                     , placeholder = "Your password"
+                    , htmlAttributes = [ ( "autocomplete", "current-password" ) ]
                     }
                 }
 
@@ -93,7 +95,9 @@ form =
                 , update = \value values -> { values | rememberMe = value }
                 , error = always Nothing
                 , attributes =
-                    { label = "Remember me" }
+                    { label = "Remember me"
+                    , htmlAttributes = []
+                    }
                 }
     in
     Form.succeed LogIn

--- a/examples/src/Page/Signup.elm
+++ b/examples/src/Page/Signup.elm
@@ -148,6 +148,7 @@ form =
                 , attributes =
                     { label = "E-Mail"
                     , placeholder = "some@email.com"
+                    , htmlAttributes = [ ( "autocomplete", "email" ) ]
                     }
                 }
 
@@ -160,6 +161,7 @@ form =
                 , attributes =
                     { label = "Name"
                     , placeholder = "Your name"
+                    , htmlAttributes = [ ( "autocomplete", "name" ) ]
                     }
                 }
 
@@ -172,6 +174,7 @@ form =
                 , attributes =
                     { label = "Password"
                     , placeholder = "Your password"
+                    , htmlAttributes = [ ( "autocomplete", "new-password" ) ]
                     }
                 }
 
@@ -194,6 +197,7 @@ form =
                         , attributes =
                             { label = "Repeat password"
                             , placeholder = "Your password again..."
+                            , htmlAttributes = [ ( "autocomplete", "new-password" ) ]
                             }
                         }
                 )
@@ -224,6 +228,7 @@ form =
                                     , langLabel lang
                                     )
                                 )
+                    , htmlAttributes = []
                     }
                 }
 
@@ -240,7 +245,9 @@ form =
                 , update = \value values -> { values | acceptTerms = value }
                 , error = always Nothing
                 , attributes =
-                    { label = "Accept Terms and Conditions" }
+                    { label = "Accept Terms and Conditions"
+                    , htmlAttributes = []
+                    }
                 }
 
         langLabel lang =

--- a/examples/src/Page/ValidationStrategies.elm
+++ b/examples/src/Page/ValidationStrategies.elm
@@ -80,6 +80,7 @@ form =
                     , options =
                         [ Form.View.ValidateOnSubmit, Form.View.ValidateOnBlur ]
                             |> List.map strategyToOption
+                    , htmlAttributes = []
                     }
                 }
 
@@ -100,6 +101,7 @@ form =
                 , attributes =
                     { label = "E-Mail"
                     , placeholder = "some@email.com"
+                    , htmlAttributes = []
                     }
                 }
 
@@ -112,6 +114,7 @@ form =
                 , attributes =
                     { label = "Name"
                     , placeholder = "Your name"
+                    , htmlAttributes = []
                     }
                 }
 
@@ -124,6 +127,7 @@ form =
                 , attributes =
                     { label = "Password"
                     , placeholder = "Your password"
+                    , htmlAttributes = []
                     }
                 }
     in

--- a/src/Form/Base/CheckboxField.elm
+++ b/src/Form/Base/CheckboxField.elm
@@ -41,7 +41,9 @@ You need to provide these to:
 
 -}
 type alias Attributes =
-    { label : String }
+    { label : String
+    , htmlAttributes : List ( String, String )
+    }
 
 
 {-| Builds a [`Form`](Form-Base#Form) with a single `CheckboxField`.

--- a/src/Form/Base/NumberField.elm
+++ b/src/Form/Base/NumberField.elm
@@ -48,6 +48,7 @@ type alias Attributes number =
     , step : Maybe number
     , min : Maybe number
     , max : Maybe number
+    , htmlAttributes : List ( String, String )
     }
 
 

--- a/src/Form/Base/RadioField.elm
+++ b/src/Form/Base/RadioField.elm
@@ -43,6 +43,7 @@ You need to provide these to:
 type alias Attributes =
     { label : String
     , options : List ( String, String )
+    , htmlAttributes : List ( String, String )
     }
 
 

--- a/src/Form/Base/RangeField.elm
+++ b/src/Form/Base/RangeField.elm
@@ -49,6 +49,7 @@ type alias Attributes number =
     , step : number
     , min : Maybe number
     , max : Maybe number
+    , htmlAttributes : List ( String, String )
     }
 
 

--- a/src/Form/Base/SelectField.elm
+++ b/src/Form/Base/SelectField.elm
@@ -44,6 +44,7 @@ type alias Attributes =
     { label : String
     , placeholder : String
     , options : List ( String, String )
+    , htmlAttributes : List ( String, String )
     }
 
 

--- a/src/Form/Base/TextField.elm
+++ b/src/Form/Base/TextField.elm
@@ -49,6 +49,7 @@ You need to provide these to:
 type alias Attributes =
     { label : String
     , placeholder : String
+    , htmlAttributes : List ( String, String )
     }
 
 

--- a/src/Form/View.elm
+++ b/src/Form/View.elm
@@ -760,6 +760,7 @@ inputField type_ { onChange, onBlur, disabled, value, error, showError, attribut
          , Attributes.type_ type_
          ]
             |> withMaybeAttribute Events.onBlur onBlur
+            |> withHtmlAttributes attributes.htmlAttributes
         )
         []
         |> withLabelAndError attributes.label showError error
@@ -774,6 +775,7 @@ textareaField { onChange, onBlur, disabled, value, error, showError, attributes 
          , Attributes.value value
          ]
             |> withMaybeAttribute Events.onBlur onBlur
+            |> withHtmlAttributes attributes.htmlAttributes
         )
         []
         |> withLabelAndError attributes.label showError error
@@ -798,6 +800,7 @@ numberField { onChange, onBlur, disabled, value, error, showError, attributes } 
             |> withMaybeAttribute (String.fromFloat >> Attributes.max) attributes.max
             |> withMaybeAttribute (String.fromFloat >> Attributes.min) attributes.min
             |> withMaybeAttribute Events.onBlur onBlur
+            |> withHtmlAttributes attributes.htmlAttributes
         )
         []
         |> withLabelAndError attributes.label showError error
@@ -817,6 +820,7 @@ rangeField { onChange, onBlur, disabled, value, error, showError, attributes } =
                 |> withMaybeAttribute (String.fromFloat >> Attributes.max) attributes.max
                 |> withMaybeAttribute (String.fromFloat >> Attributes.min) attributes.min
                 |> withMaybeAttribute Events.onBlur onBlur
+                |> withHtmlAttributes attributes.htmlAttributes
             )
             []
         , Html.span [] [ Html.text (value |> Maybe.map String.fromFloat |> Maybe.withDefault "") ]
@@ -834,6 +838,7 @@ checkboxField { onChange, onBlur, value, disabled, error, showError, attributes 
              , Attributes.type_ "checkbox"
              ]
                 |> withMaybeAttribute Events.onBlur onBlur
+                |> withHtmlAttributes attributes.htmlAttributes
             )
             []
         , Html.text attributes.label
@@ -857,6 +862,7 @@ radioField { onChange, onBlur, disabled, value, error, showError, attributes } =
                      , Events.onClick (onChange key)
                      ]
                         |> withMaybeAttribute Events.onBlur onBlur
+                        |> withHtmlAttributes attributes.htmlAttributes
                     )
                     []
                 , Html.text label
@@ -892,6 +898,7 @@ selectField { onChange, onBlur, disabled, value, error, showError, attributes } 
          , Attributes.disabled disabled
          ]
             |> withMaybeAttribute Events.onBlur onBlur
+            |> withHtmlAttributes attributes.htmlAttributes
         )
         (placeholderOption :: List.map toOption attributes.options)
         |> withLabelAndError attributes.label showError error
@@ -982,6 +989,12 @@ withMaybeAttribute : (a -> Html.Attribute msg) -> Maybe a -> List (Html.Attribut
 withMaybeAttribute toAttribute maybeValue attrs =
     Maybe.map (toAttribute >> (\attr -> attr :: attrs)) maybeValue
         |> Maybe.withDefault attrs
+
+
+withHtmlAttributes : List ( String, String ) -> List (Html.Attribute msg) -> List (Html.Attribute msg)
+withHtmlAttributes list attributes =
+    List.map (\( a, b ) -> Attributes.attribute a b) list
+        |> (++) attributes
 
 
 fromString : (String -> Maybe a) -> Maybe a -> String -> Maybe a

--- a/tests/Base.elm
+++ b/tests/Base.elm
@@ -398,6 +398,7 @@ andThen =
                 , attributes =
                     { label = "Title"
                     , placeholder = "Write a title..."
+                    , htmlAttributes = []
                     }
                 }
 
@@ -410,6 +411,7 @@ andThen =
                 , attributes =
                     { label = "Body"
                     , placeholder = "Write the body..."
+                    , htmlAttributes = []
                     }
                 }
 
@@ -623,6 +625,7 @@ emailField =
         , attributes =
             { label = "E-Mail"
             , placeholder = "Type your e-mail..."
+            , htmlAttributes = []
             }
         }
 
@@ -652,6 +655,7 @@ passwordField =
         , attributes =
             { label = "Password"
             , placeholder = "Type your password..."
+            , htmlAttributes = []
             }
         }
 
@@ -685,6 +689,7 @@ repeatPasswordField =
                 , attributes =
                     { label = "Repeat password"
                     , placeholder = "Type your password again..."
+                    , htmlAttributes = []
                     }
                 }
         )
@@ -725,6 +730,7 @@ contentTypeField =
             { label = "Content type"
             , placeholder = "Select a type of content"
             , options = [ ( "post", "Post" ), ( "question", "Question" ) ]
+            , htmlAttributes = []
             }
         }
 

--- a/tests/View.elm
+++ b/tests/View.elm
@@ -94,6 +94,7 @@ nameField =
         , attributes =
             { label = "Name"
             , placeholder = "Type your name..."
+            , htmlAttributes = []
             }
         }
 
@@ -108,5 +109,6 @@ surnameField =
         , attributes =
             { label = "Surname"
             , placeholder = "Type your surname..."
+            , htmlAttributes = []
             }
         }


### PR DESCRIPTION
Add ability to add any custom HTML attributes to FieldConfigs.
Defaults to empty list for small impact if not used.

Use cases:
* Need to identify the rendered fields in end-to-end tests to fill them out
* Add `autocomplete` attributes for browser autofill